### PR TITLE
Add VBS NCrypt key attestation sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This sample provides the code implementation to perform boot attestation, and re
 This sample provides the code implementation to perform boot and TPM key attestation, and retrieve an attestation token from Microsoft Azure Attestation.
 This sample creates a TPM key named "att_sample_key" which is attested by Microsoft Azure Attestation. The creation of a TPM key may take up to a few minutes depending on the TPM hardware.
 
+### **VBS Ncrypt key attestation (sample_vbs_ncrypt_att.exe)**
+
+This sample provides the code implementation to perform VBS NCrypt key attestation, and retrieve an attestation token from Microsoft Azure Attestation.
+This sample creates a VBS NCrypt key named "att_sample_key" which is attested by Microsoft Azure Attestation.
+
 ## Sample Requirements
 
 * The machine must have a Trusted Platform Module (TPM).

--- a/attestation/CMakeLists.txt
+++ b/attestation/CMakeLists.txt
@@ -34,3 +34,4 @@ endmacro()
 
 define_sample(sample_boot_att)
 define_sample(sample_tpm_key_att)
+define_sample(sample_vbs_ncrypt_att)

--- a/attestation/sample_vbs_ncrypt_att.cpp
+++ b/attestation/sample_vbs_ncrypt_att.cpp
@@ -1,0 +1,85 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+/**
+ * @brief This sample provides the code implementation to perform boot and TPM key attestation,
+ * and retrieve an attestation token from Microsoft Azure Attestation.
+ *
+ * @remark The following environment variables must be set before running the sample.
+ *
+ * - AZURE_TENANT_ID:     Tenant ID for the Azure account. Used for authenticated calls to the attestation service.
+ * - AZURE_CLIENT_ID:     The client ID to authenticate the request. Used for authenticated calls to the attestation service.
+ * - AZURE_CLIENT_SECRET: The client secret. Used for authenticated calls to the attestation service.
+ * - AZURE_MAA_URI:       Microsoft Azure Attestation provider's Attest URI (as shown in portal). Format is similar to "https://<ProviderName>.<Region>.attest.azure.net".
+ *
+ * In addition, a TPM attestation identity key named 'att_sample_aik' must be created. See README.md for instructions.
+ *
+ * Finally, a fixed relying party id and nonce are used in this sample. An application should obtain a per-session nonce from the relying party before making
+ * the call to the attestation service. TODOs in the code below mark the locations to be updated.
+ *
+ */
+
+#include "utils.h"
+#include "attest.h"
+#include <string>
+#include <vector>
+#include <iostream>
+
+#include <att_manager.h>
+
+using namespace std;
+
+#define AIK_NAME L"att_sample_aik"
+
+int main()
+{
+    if (!CanCreateKeyGuardKey()) {
+        cout << "Key Guard unavailable" << endl;
+        return 0;
+    }
+    else {
+        cout << "Key Guard available" << endl;
+    }
+
+    // TODO: Use relying party's id in the line below.
+    string rp_id{ "https://contoso.com" };
+    // TODO: Use relying party's per-session nonce below.
+    vector<uint8_t> rp_nonce{ 'R', 'E','P','L','A','C','E',' ','W','I','T','H', ' ','R','P', ' ','N','O','N','C','E' };
+
+    try
+    {
+        auto tpm_aik = load_tpm_key(AIK_NAME, true);
+        auto vbs_key = create_key(MS_KEY_STORAGE_PROVIDER, L"att_sample_key", NCRYPT_OVERWRITE_KEY_FLAG | NCRYPT_USE_VIRTUAL_ISOLATION_FLAG, true);
+
+        att_tpm_aik aik = ATT_TPM_AIK_NCRYPT(tpm_aik.get());
+        att_tpm_key key = ATT_TPM_KEY_VBS_NCRYPT(vbs_key.get());
+
+        att_session_params_tpm params
+        {
+            rp_nonce.data(), // relying_party_nonce
+            rp_nonce.size(), // relying_party_nonce_size
+            rp_id.c_str(),   // relying_party_unique_id
+            &aik,            // aik
+            &key,            // request_key
+            nullptr,         // other_keys
+            0                // other_keys_count
+        };
+
+        attest(params, "report_key.jwt");
+    }
+    catch (const std::exception& ex)
+    {
+        cout << ex.what() << endl;
+    }
+
+    return 0;
+
+    //
+    // Notice that report will contain claim "x-ms-tpm-request-key", which includes the public part of the TPM key in the "jwk" field.
+    // In addition, field "info" will contains "tpm_certify" indicating that a TPM key was certified. The fields inside "tpm_certify" attest to the TPM key properties. Those properties 
+    // are described in Trusted Computing Group's TPM Library spec (https://trustedcomputinggroup.org/resource/tpm-library-specification/), Part 2: Structures, TPMT_PUBLIC. For example,
+    // a relying party can verify that the key's object attributes have bits fixedTPM, fixedParent and sensitiveDataOrigin set to make sure the key was generated inside the TPM and cannot
+    // be exported.
+    //
+}

--- a/attestation/utils.cpp
+++ b/attestation/utils.cpp
@@ -28,20 +28,90 @@ wil::unique_ncrypt_key create_tpm_key(const wstring& name, bool machine_key)
 {
     cout << "Creating TPM key...";
 
-    wil::unique_ncrypt_prov tpm_prov{};
-    THROW_IF_FAILED_MSG(NCryptOpenStorageProvider(&tpm_prov, MS_PLATFORM_KEY_STORAGE_PROVIDER, 0), "Error opening TPM provider.");
-
-    wil::unique_ncrypt_key tpm_key{};
-    THROW_IF_FAILED_MSG(NCryptCreatePersistedKey(tpm_prov.get(), &tpm_key, BCRYPT_RSA_ALGORITHM, name.c_str(), 0, NCRYPT_OVERWRITE_KEY_FLAG | (machine_key ? NCRYPT_MACHINE_KEY_FLAG : 0)), "Error creating TPM key.");
-
-    DWORD key_len = 2048;
-    THROW_IF_FAILED_MSG(NCryptSetProperty(tpm_key.get(), NCRYPT_LENGTH_PROPERTY, reinterpret_cast<PBYTE>(&key_len), sizeof(key_len), 0), "Error setting key length.");
+    auto tpm_key = create_key(MS_PLATFORM_KEY_STORAGE_PROVIDER, name, NCRYPT_OVERWRITE_KEY_FLAG | (machine_key ? NCRYPT_MACHINE_KEY_FLAG : 0), false);
 
     THROW_IF_FAILED_MSG(NCryptFinalizeKey(tpm_key.get(), 0), "Error finalizing TPM key.");
 
     cout << " Done." << endl;
 
     return tpm_key;
+}
+
+wil::unique_ncrypt_key create_key(PCWSTR providerName, const wstring& keyName, DWORD flags, bool finalize)
+{
+    wil::unique_ncrypt_prov provHandle{};
+    THROW_IF_FAILED_MSG(NCryptOpenStorageProvider(
+        &provHandle,
+        providerName,
+        0), "NCryptOpenStorageProvider failed.");
+
+    wil::unique_ncrypt_key key{};
+    THROW_IF_FAILED_MSG(NCryptCreatePersistedKey(
+        provHandle.get(),
+        &key,
+        BCRYPT_RSA_ALGORITHM,
+        keyName.c_str(),
+        0,
+        flags), "NCryptCreatePersistedKey failed.");
+
+    DWORD key_len = 2048;
+    THROW_IF_FAILED_MSG(
+        NCryptSetProperty(
+            key.get(),
+            NCRYPT_LENGTH_PROPERTY,
+            reinterpret_cast<PBYTE>(&key_len),
+            sizeof(key_len),
+            0), "NCryptSetProperty for key length failed.");
+
+    if (finalize)
+    {
+        THROW_IF_FAILED_MSG(NCryptFinalizeKey(key.get(), 0), "NCryptFinalizeKey failed.");
+    }
+
+    return key;
+}
+
+bool CanCreateKeyGuardKey()
+{
+    // bool result = false;
+
+    SECURITY_STATUS status;
+    NCRYPT_PROV_HANDLE hProv = 0;
+    NCRYPT_KEY_HANDLE hKey = 0;
+
+    status = NCryptOpenStorageProvider(&hProv, MS_KEY_STORAGE_PROVIDER, 0);
+    if (status != ERROR_SUCCESS)
+    {
+        wprintf(L"NCryptOpenStorageProvider failed with %x\n", status);
+        if (hKey)
+        {
+            NCryptFreeObject(hKey);
+        }
+
+        if (hProv)
+        {
+            NCryptFreeObject(hProv);
+        }
+        return false;
+    }
+
+    status = NCryptCreatePersistedKey(hProv, &hKey, NCRYPT_ECDSA_P384_ALGORITHM, NULL, 0, NCRYPT_USE_VIRTUAL_ISOLATION_FLAG);
+    if (status != ERROR_SUCCESS)
+    {
+        wprintf(L"NCryptCreatePersistedKey failed with %x\n", status);
+        if (hKey)
+        {
+            NCryptFreeObject(hKey);
+        }
+
+        if (hProv)
+        {
+            NCryptFreeObject(hProv);
+        }
+        return false;
+    }
+
+    return true;
 }
 
 std::string get_env_var(const std::string& env)

--- a/attestation/utils.h
+++ b/attestation/utils.h
@@ -14,6 +14,12 @@ wil::unique_ncrypt_key load_tpm_key(const std::wstring& name, bool machine_key);
 // Creates a 2048-bit RSA key in the TPM using the Platform Key Storage Provider.
 wil::unique_ncrypt_key create_tpm_key(const std::wstring& name, bool machine_key);
 
+// Creates a 2048-bit RSA key
+wil::unique_ncrypt_key create_key(PCWSTR providerName, const std::wstring& keyName, DWORD flags, bool finalize);
+
+// Returns true if a Key Guard key can be created.
+bool CanCreateKeyGuardKey();
+
 // Returns the value of an environment variable.
 std::string get_env_var(const std::string& env);
 

--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -22,7 +22,7 @@ macro(az_vcpkg_integrate)
       if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
         # GET VCPKG FROM SOURCE
         #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-        set(VCPKG_COMMIT_STRING acc3bcf76b84ae5041c86ab55fe138ae7b8255c7) # default SDK tested commit
+        set(VCPKG_COMMIT_STRING fba75d09065fcc76a25dcf386b1d00d33f5175af) # default SDK tested commit
         if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
           set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
         endif()


### PR DESCRIPTION
Add sample for attestation of VBS NCrypt (Key Guard) keys.

New sample runs and attests in KG enabled device.