### PR TITLE
BUG FIX: Resolve Download Nuget Error Message when Configuring CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT NUGET_EXE)
 endif()
 
 if(NOT NUGET_EXE)
-    message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads!")
+    message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads and move it to your Attestation-Client-Samples Directory!")
 else()
     exec_program(${NUGET_EXE}
         ARGS install "Microsoft.Attestation.Client" -Version 0.1.181 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,24 @@ cmake_minimum_required (VERSION 3.12)
 
 set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/cmake-modules/overlay-ports")
 
+set(NUGET_VERSION "latest")
+
+set(DOWNLOAD_NUGET_URL "https://dist.nuget.org/win-x86-commandline/${NUGET_VERSION}/nuget.exe")
+
+unset(NUGET_EXE CACHE)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 include(AzureVcpkg)
 az_vcpkg_integrate()
 
 project(samples)
 
-find_program(NUGET_EXE NAMES nuget)
+find_program(NUGET_EXE NAMES nuget nuget.exe HINTS ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT NUGET_EXE)
+    file(DOWNLOAD ${DOWNLOAD_NUGET_URL} "${CMAKE_CURRENT_SOURCE_DIR}/nuget.exe")
+    find_program(NUGET_EXE NAMES nuget nuget.exe HINTS ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 if(NOT NUGET_EXE)
     message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT NUGET_EXE)
 endif()
 
 if(NOT NUGET_EXE)
-    message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads and move it to your Attestation-Client-Samples Directory!")
+    message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads and move it to ${CMAKE_CURRENT_SOURCE_DIR}!")
 else()
     exec_program(${NUGET_EXE}
         ARGS install "Microsoft.Attestation.Client" -Version 0.1.181 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)

--- a/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
+++ b/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
@@ -11,7 +11,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.7.0-beta.1"
+      "version>=": "1.7.0"
     },
     "openssl",
     {

--- a/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
+++ b/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
@@ -11,7 +11,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.7.1"
+      "version>=": "1.13.0"
     },
     "openssl",
     {

--- a/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
+++ b/cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json
@@ -11,7 +11,7 @@
     {
       "name": "azure-core-cpp",
       "default-features": false,
-      "version>=": "1.7.0"
+      "version>=": "1.7.1"
     },
     "openssl",
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,5 +5,6 @@
     "azure-identity-cpp",
     "azure-security-attestation-cpp",
     "wil"
-  ]
+  ],
+  "builtin-baseline": "6af584dd59aa5bdba75dae6781ec74614e03e5b9"
 }


### PR DESCRIPTION
**Changes:**
- I changed line 14 in CMakeLists.txt from "find_program(NUGET_EXE NAMES nuget nuget.exe)" to "find_program(NUGET_EXE NAMES nuget nuget.exe HINTS ${CMAKE_CURRENT_SOURCE_DIR})". The executable was named "nuget.exe" instead of "nuget," so I added the additional NAME "nuget.exe" so that CMake looks for both options. Adding a HINT allowed CMake to parse the correct directory, instead of getting lost. 
- I added the functionality to download NuGet if it is not found with consideration for versioning. Right now, the program downloads the latest version of NuGet, but that can be altered if there is another preferred version.
- I updated the error message to specify where we want the customer to download the NuGet executable (i.e. in the Attestation-Client-Samples directory) so that the error message doesn't persist because the executable exists in a different directory than anticipated.
- I had to add this line: "unset(NUGET_EXE CACHE)" because if I delete nuget.exe after successfully running the CMake and re-configure, the program will error stating that CMake cannot find the file because the find_program macro won't run if the variable NUGET_EXE was previously set. The macro won't run in this case because NUGET_EXE is a cache entry, not a normal variable. 
- I added a builtin-baseline in vcpkg.json for the "samples" dependency because[ a change](https://github.com/lukka/run-vcpkg/pull/216) was made to vcpkg to require a baseline. Because of this, I received an error stating that vcpkg requires a built-in baseline when I tried to configure the CMake. I ran "./vcpkg/vcpkg.exe x-update-baseline add-initial-baseline" to obtain the built-in baseline value.
- I changed the version from "version>=": "1.7.0-beta.1" to "version>=": "1.7.0" in cmake-modules/overlay-ports/azure-security-attestation-cpp/vcpkg.json for the "azure-core-cpp" dependency because I was getting an error that the version "1.70-beta.1" does not exist when I tried to configure the CMake.

**Next Steps:**
- Add another hint to check the customer's downloads folder, if this is possible and/or desired.

**Callouts for Review:**
- Is the version change to >="1.7.0" acceptable or is there another version that this should be changed to?
- Is downloading nuget.exe into the customer's Attestation-Client-Samples directory acceptable?
- Is there a version of NuGet that is preferred over the latest version?

**Resources Used:**
- [CMake find_program Documentation](https://cmake.org/cmake/help/latest/command/find_program.html)
- [StackOverflow CMake Doesn't Find "lib.exe"](https://stackoverflow.com/questions/54269654/cmake-find-program-command-does-not-find-lib-exe)
- [CMake file Documentation](https://cmake.org/cmake/help/v3.3/command/file.html)
- [StackOverflow How To Download Files with CMake](https://stackoverflow.com/questions/39022188/how-to-download-arbitrary-files-as-part-of-a-custom-target-with-cmake)

**Summary of Reasoning/Changes:**
I noticed that if you view the NuGet executable from the command line, it showed the executable name as "nuget.exe". If you look at the executable from the folder view outside of the command line, the name appears as "nuget". Because the NUGET_EXE variable is set in line 14 of CMakeLists.txt, I decided that line and the find_program macro was what was causing the issue. I looked up the [CMake documentation for the find_program](https://cmake.org/cmake/help/latest/command/find_program.html) macro and saw that you can add additional "NAMES," so I changed line 14 from "find_program(NUGET_EXE NAMES nuget)" to "find_program(NUGET_EXE NAMES nuget nuget.exe)" because I assumed that the program was going to look for the .exe naming style that the command line was showing. That still wasn't working, so I found [this Stack Overflow post](https://stackoverflow.com/questions/54269654/cmake-find-program-command-does-not-find-lib-exe) where one of the commenters said to add hints to make it easier for the program to find the executable, so I changed line 14 from "find_program(NUGET_EXE NAMES nuget nuget.exe)" to  "find_program(NUGET_EXE NAMES nuget nuget.exe HINTS ${CMAKE_CURRENT_SOURCE_DIR})" and that worked. I added a message statement (now deleted for code quality) to show me which naming style it did end up looking for and it showed the path as "C:/Users/cacreamer/Attestation-Client-Samples/nuget.exe", so it is looking for a file ending in .exe. To make it so that we don't have to ship "nuget.exe" with the samples, I found a macro called file() that allows you to download files via a URL, and added the capability to download the NuGet executable if it does not already exist within the customer's directory. I set the NuGet version in a variable called NUGET_VERSION to "latest" so that CMake downloads the most recent version, but this can be altered.