### PR TITLE
Add VBS Enclave Attestation sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required(VERSION 3.29)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/cmake-modules/overlay-ports")
 
@@ -25,10 +28,87 @@ if(NOT NUGET_EXE)
 endif()
 
 if(NOT NUGET_EXE)
-    message(FATAL "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads and move it to ${CMAKE_CURRENT_SOURCE_DIR}!")
+    message(FATAL_ERROR "CMake could not find the nuget command line tool. Please install it from https://www.nuget.org/downloads and move it to ${CMAKE_CURRENT_SOURCE_DIR}!")
 else()
-    exec_program(${NUGET_EXE}
-        ARGS install "Microsoft.Attestation.Client" -Version 0.1.181 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
+    execute_process(
+        COMMAND ${NUGET_EXE} install "Microsoft.Attestation.Client" -Version 0.1.181 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages
+        RESULT_VARIABLE NUGET_RESULT
+        OUTPUT_VARIABLE NUGET_OUTPUT
+        ERROR_VARIABLE NUGET_ERROR
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    if(NUGET_RESULT)
+        message(FATAL_ERROR "NuGet package installation failed: ${NUGET_ERROR}")
+    else()
+        message(STATUS "NuGet package installed successfully: ${NUGET_OUTPUT}")
+    endif()
+endif()
+
+unset(DOTNET_EXE CACHE)
+set(DOTNET_VERSION "9.0")
+set(DOTNET_INSTALL_URL "https://dotnet.microsoft.com/en-us/download/dotnet/${DOTNET_VERSION}")
+
+# Find dotnet.exe
+find_program(DOTNET_EXE NAMES dotnet dotnet.exe)
+
+# If not found, download and install it
+if(NOT DOTNET_EXE)
+    message(STATUS "Downloading .NET SDK ${DOTNET_VERSION}...")
+
+    set(DOTNET_INSTALLER "${CMAKE_BINARY_DIR}/dotnet-installer.exe")
+    
+    # Download .NET installer
+    file(DOWNLOAD 
+        "https://download.visualstudio.microsoft.com/download/pr/50b4d70f-0dd8-4323-8b76-94b23fd32a3a/d6f065ac712214e8d9fa4bb1d0cbf74d/dotnet-sdk-${DOTNET_VERSION}-win-x64.exe" 
+        ${DOTNET_INSTALLER}
+        SHOW_PROGRESS
+    )
+
+    message(STATUS "Installing .NET SDK...")
+
+    # Run the installer silently
+    execute_process(
+        COMMAND ${DOTNET_INSTALLER} /quiet /norestart
+        RESULT_VARIABLE DOTNET_INSTALL_RESULT
+        OUTPUT_VARIABLE DOTNET_INSTALL_OUTPUT
+        ERROR_VARIABLE DOTNET_INSTALL_ERROR
+    )
+
+    if(DOTNET_INSTALL_RESULT)
+        message(FATAL_ERROR "Failed to install .NET SDK: ${DOTNET_INSTALL_ERROR}")
+    else()
+        message(STATUS "Successfully installed .NET SDK.")
+    endif()
+
+    # Find dotnet.exe again after installation
+    find_program(DOTNET_EXE NAMES dotnet dotnet.exe HINTS "$ENV{ProgramFiles}/dotnet" "$ENV{ProgramFiles(x86)}/dotnet")
+
+    if(NOT DOTNET_EXE)
+        message(FATAL_ERROR "dotnet.exe not found after installation. Ensure .NET SDK is installed and in your PATH.")
+    else()
+        message(STATUS "dotnet.exe found at: ${DOTNET_EXE}")
+    endif()
+endif()
+
+
+if(NOT DOTNET_EXE)
+    message(FATAL_ERROR "CMake could not find the dotnet command line tool. Please install .NET SDK from https://dotnet.microsoft.com/download and ensure it's in your PATH.")
+else()
+    # Install AzureSignTool as a .NET Global Tool
+    execute_process(
+        COMMAND ${DOTNET_EXE} tool install --global AzureSignTool
+        RESULT_VARIABLE AZURESIGNTOOL_RESULT
+        OUTPUT_VARIABLE AZURESIGNTOOL_OUTPUT
+        ERROR_VARIABLE AZURESIGNTOOL_ERROR
+    )
+
+    if(AZURESIGNTOOL_RESULT)
+        message(FATAL_ERROR "AzureSignTool installation failed: ${AZURESIGNTOOL_ERROR}")
+    else()
+        message(STATUS "AzureSignTool installed successfully: ${AZURESIGNTOOL_OUTPUT}")
+    endif()
 endif()
 
 add_subdirectory(attestation)
+add_subdirectory(enclave)

--- a/attestation/CMakeLists.txt
+++ b/attestation/CMakeLists.txt
@@ -1,7 +1,9 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required (VERSION 3.12)
+set(CMAKE_SYSTEM_VERSION 10.0)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 set(ATTEST_PACKAGE_DIR "${CMAKE_BINARY_DIR}/packages/Microsoft.Attestation.Client" CACHE STRING "")
 
@@ -34,3 +36,119 @@ endmacro()
 
 define_sample(sample_boot_att)
 define_sample(sample_tpm_key_att)
+
+
+if (WIN32)
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+endif()
+
+
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-security-attestation-cpp CONFIG REQUIRED)
+
+
+set(
+    HostLibs
+    kernel32.lib
+    bcrypt.lib
+    user32.lib
+    onecore.lib
+    ncrypt
+    "${ATTEST_PACKAGE_DIR}/lib/azure-attest-manager.lib"
+    "D:/VBSEnclave/AzureAttest/lib/AzureAttest.lib"
+    Azure::azure-identity
+    Azure::azure-security-attestation
+)
+
+set(
+    HostSources
+    "${CMAKE_CURRENT_SOURCE_DIR}/sample_vbs_att.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/attest.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp"
+)
+
+
+set(
+    HostIncs
+    "${CMAKE_SOURCE_DIR}/wil/include/"
+    "${ATTEST_PACKAGE_DIR}/inc"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "D:/VBSEnclave/AzureAttest/inc"
+)
+
+message(STATUS "Include directories: ${HostIncs}")
+
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+
+set(
+    bintarget
+    attestation-sample_vbs_att
+    )
+
+
+add_executable(
+    ${bintarget}
+    ${HostSources}
+    )
+
+
+if (WIN32)
+    target_precompile_headers(
+        ${bintarget}
+        PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/precomp.h"
+        )
+endif()
+
+target_link_libraries(
+    ${bintarget}
+    PRIVATE
+    ${HostLibs}
+    )
+
+target_include_directories(
+    ${bintarget}
+    PRIVATE
+    ${HostIncs}
+    )
+
+
+set_target_properties( ${bintarget} PROPERTIES WIN32_EXECUTABLE OFF)
+
+#
+# Add compiler definitions
+#
+target_compile_definitions(
+    ${bintarget}
+    PRIVATE
+    ${UCRTSETTINGS_CL_PREPROCESSOR_DEFS_COMMON}
+    )
+
+
+
+if(WIN32)
+    target_compile_options(
+        ${bintarget}
+        PRIVATE
+        "${UCRTSETTINGS_CL_FLAGS_COMMON}"
+        "${UCRTSETTINGS_CL_FLAGS_CXX}"
+        )
+        
+    target_link_options(
+        ${bintarget}
+        PRIVATE /SUBSYSTEM:CONSOLE
+        )
+endif()
+
+install(
+    TARGETS ${bintarget}
+    RUNTIME
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+
+if(WIN32)
+    install(
+        FILES $<TARGET_PDB_FILE:${bintarget}>
+        DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+endif()

--- a/attestation/attest.h
+++ b/attestation/attest.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <stdint.h>
+#include <vector>
 #include <wil/resource.h>
 
 #include <att_manager.h>
@@ -19,5 +20,8 @@ using att_buffer = wil::unique_any<uint8_t*, decltype(&att_free_buffer), att_fre
 
 // Performs the attestation loop.
 void attest(const att_session_params_tpm& params, const std::string& file_name);
+
+// Sends the data to the attestation service.
+std::vector<uint8_t> send_to_att_service(const uint8_t* data, size_t size);
 
 #endif // _ATT_SAMPLES_ATTEST_H

--- a/attestation/precomp.h
+++ b/attestation/precomp.h
@@ -1,0 +1,17 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include <windows.h>
+#include <stdio.h>
+#include <wil/resource.h>
+#include <wil/result_macros.h>

--- a/attestation/sample_vbs_att.cpp
+++ b/attestation/sample_vbs_att.cpp
@@ -1,0 +1,392 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+
+#include <windows.h>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <winhttp.h>
+#include <ncrypt.h>
+
+#include <att_manager_api_enclave.h>
+#include <att_manager_api.h>
+
+#include <attest_enclave.h>
+#include <attest.h>
+#include <utils.h>
+
+
+#define AIK_NAME L"att_sample_aik"
+
+using namespace std;
+
+typedef uint64_t ATTESTATION_SESSION_HANDLE;
+
+// initialize_attestation_library configuration flags
+
+// Always use VSM, it will fail ATT_ERROR_NOT_SUPPORTED if VSM is not supported
+#define ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_VSM_MODE_ALWAYS       0x0
+
+// Always use normal mode
+#define ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_NORMAL_MODE_ALWAYS    0x1
+
+// Use VSM mode if supported, otherwise use normal mode
+#define ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_VSM_MODE_IF_SUPPORTED 0x2
+
+//
+// attestation_configure and attestation_call are address pointers to the export functions exposed by the enclave
+// See attest_enclave.h for more detail
+//
+struct ENCLAVE_ATTESTATION_FUNCTION_TABLE
+{
+    LPENCLAVE_ROUTINE attestation_configure;
+    LPENCLAVE_ROUTINE attestation_create_session;
+    LPENCLAVE_ROUTINE attestation_attest;
+    LPENCLAVE_ROUTINE attestation_get_report;
+    LPENCLAVE_ROUTINE attestation_close_session;
+};
+
+// attestation_flag is optional and can be 0. It is used to override the default behavior which is ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_VSM_MODE_ALWAYS flag
+//            Currently supports:
+//                ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_VSM_MODE_ALWAYS
+//                ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_NORMAL_MODE_ALWAYS
+//                ENCLAVE_ATTESTATION_INIT_LIBRARY_USE_VSM_MODE_IF_SUPPORTED
+// attestation_identity_key_name is optional and can be NULL. If it's NULL, "Windows AIK" will be used.
+// attestation_function_table is required. See enclave_attestation_function_table definition for more detail.
+struct ENCLAVE_ATTESTATION_INIT_LIBRARY_CONFIGURATION
+{
+    uint32_t                              attestation_flag;
+    const char*                           attestation_identity_key_name;
+    enclave_attestation_function_table    attestation_function_table;
+};
+
+struct enclave_attestation_callback_function_table
+{
+    uint32_t          version;
+    LPENCLAVE_ROUTINE allocate_params;
+    LPENCLAVE_ROUTINE allocate_memory;
+    LPENCLAVE_ROUTINE free_memory;
+    LPENCLAVE_ROUTINE get_tcg_log;
+    LPENCLAVE_ROUTINE trace_log;
+    LPENCLAVE_ROUTINE get_metadata;
+    LPENCLAVE_ROUTINE get_key_info;
+    LPENCLAVE_ROUTINE sign_hash;
+};
+
+struct enclave_attestation_configure_params
+{
+    size_t size;
+
+    // Input params.
+    enclave_attestation_callback_function_table callback_function_able;
+};
+
+struct create_session_params
+{
+    size_t size;
+
+    // Input params.
+    const uint8_t* relying_party_custom_data;
+    uint32_t relying_party_custom_data_size;
+    const char* relying_party_unique_id;
+    uint32_t relying_party_unique_id_size;
+    uint32_t session_flags;
+    const att_tpm_aik* attestation_identity_key;
+    const att_tpm_key* request_key;
+    const att_tpm_key* other_keys;
+    uint32_t other_keys_count;
+
+    // Output params.
+    ATTESTATION_SESSION_HANDLE attestation_session_handle;
+};
+
+struct enclave_attestation_create_session_params
+{
+    create_session_params params;
+    enclave_attestation_property* enclave_properties;
+    uint32_t enclave_properties_size;
+    uint32_t flags;
+};
+
+struct enclave_attestation_attest_params
+{
+    size_t size;
+
+    // Input params.
+    ATTESTATION_SESSION_HANDLE attestation_session_handle;
+    const UINT8* input;
+    UINT32 input_size;
+
+    // Output params.
+    uint8_t* output;
+    UINT32 buffer_size;
+    UINT32 output_size;
+    bool complete;
+};
+
+struct enclave_attestation_get_report_params
+{
+    size_t size;
+
+    // Input params.
+    ATTESTATION_SESSION_HANDLE attestation_session_handle;
+
+    // Output params.
+    uint8_t* report;
+    uint32_t buffer_size;
+    uint32_t report_size;
+};
+
+struct enclave_attestation_close_session_params
+{
+    size_t size;
+
+    // Input params.
+    ATTESTATION_SESSION_HANDLE attestation_session_handle;
+};
+
+
+void log_and_exit_if_failed(HRESULT hr, LPCWSTR message)
+{
+    if (FAILED(hr))
+    {
+        LPWSTR errorText = nullptr;
+        FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+            nullptr,
+            hr,
+            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            (LPWSTR)&errorText,
+            0,
+            nullptr);
+
+        std::wcout << message << std::endl << L"HRESULT: " << hr << std::endl;
+        if (errorText)
+        {
+            std::wcout << L"Error: " << errorText << std::endl;
+            LocalFree(errorText);
+        }
+        exit(hr);
+    }
+}
+
+
+
+wil::unique_ncrypt_key create_key(PCWSTR provider_name, PCWSTR key_name, DWORD flags, bool finalize)
+{
+    wil::unique_ncrypt_prov prov_handle{};
+    THROW_IF_FAILED_MSG(NCryptOpenStorageProvider(
+        &prov_handle,
+        provider_name,
+        0), "NCryptOpenStorageProvider failed.");
+
+    wil::unique_ncrypt_key key{};
+    THROW_IF_FAILED_MSG(NCryptCreatePersistedKey(
+        prov_handle.get(),
+        &key,
+        BCRYPT_RSA_ALGORITHM,
+        key_name,
+        0,
+        flags), "NCryptCreatePersistedKey failed.");
+
+    DWORD key_length = 2048;
+    THROW_IF_FAILED_MSG(NCryptSetProperty(
+        key.get(),
+        NCRYPT_LENGTH_PROPERTY,
+        (PBYTE)&key_length,
+        sizeof(key_length),
+        0), "NCryptSetProperty for key length failed.");
+
+    SECURITY_DESCRIPTOR sec_descr{};
+    if (!InitializeSecurityDescriptor(&sec_descr, SECURITY_DESCRIPTOR_REVISION))
+    {
+        log_and_exit_if_failed(GetLastError(), L"InitializeSecurityDescriptor error: 0x%d");
+        THROW_WIN32(GetLastError());
+    }
+
+    THROW_IF_FAILED_MSG(NCryptSetProperty(
+        key.get(),
+        NCRYPT_SECURITY_DESCR_PROPERTY,
+        (PBYTE)&sec_descr,
+        sizeof(sec_descr),
+        DACL_SECURITY_INFORMATION), "NCryptSetProperty for security descriptor failed.");
+
+    if (finalize)
+    {
+        THROW_IF_FAILED_MSG(NCryptFinalizeKey(key.get(), 0), "NCryptFinalizeKey failed.");
+    }
+
+    return key;
+}
+
+LPVOID g_enclave_base = nullptr;
+
+void create_enclave()
+{
+    ENCLAVE_CREATE_INFO_VBS create_info =
+    {
+        0,
+        { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F }
+    };
+
+    g_enclave_base = CreateEnclave(GetCurrentProcess(),
+        0,
+        0x10000000,
+        0,
+        ENCLAVE_TYPE_VBS,
+        &create_info,
+        sizeof(create_info),
+        nullptr);
+
+    if (g_enclave_base == nullptr)
+    {
+        log_and_exit_if_failed(HRESULT_FROM_WIN32(GetLastError()), L"CreateEnclave failed");
+    }
+
+    else if (!LoadEnclaveImageW(g_enclave_base, L"vbsenclave.dll"))
+    {
+        log_and_exit_if_failed(HRESULT_FROM_WIN32(GetLastError()), L"LoadEnclaveImage failed");
+    }
+
+    ENCLAVE_INIT_INFO_VBS init_info =
+    {
+        sizeof(init_info),   // length
+		1                   // thread_count
+    };
+
+    if (!InitializeEnclave(GetCurrentProcess(),
+        g_enclave_base,
+        &init_info,
+        init_info.Length,
+        nullptr))
+    {
+        log_and_exit_if_failed(HRESULT_FROM_WIN32(GetLastError()), L"InitializeEnclave failed");
+    }
+
+}
+
+LPENCLAVE_ROUTINE load_enclave_export(LPCSTR procName)
+{
+    LPENCLAVE_ROUTINE address = reinterpret_cast<LPENCLAVE_ROUTINE>(GetProcAddress(reinterpret_cast<HMODULE>(g_enclave_base), procName));
+    if (address == nullptr)
+    {
+        log_and_exit_if_failed(HRESULT_FROM_WIN32(GetLastError()), L"GetProcAddress failed");
+    }
+
+    return address;
+}
+
+void initialize()
+{
+    ENCLAVE_ATTESTATION_INIT_LIBRARY_CONFIGURATION init_library_configuration{
+        0,
+        "att_sample_aik",
+        {
+            load_enclave_export("sample_enclave_att_configure"),
+            load_enclave_export("sample_enclave_att_create_session"),
+            load_enclave_export("sample_enclave_att_attest"),
+            load_enclave_export("sample_enclave_att_get_report"),
+            load_enclave_export("sample_enclave_att_close_session")
+        }
+    };
+
+    log_and_exit_if_failed(initialize_attestation_library(&init_library_configuration), L"initialize_attestation_library failed");
+}
+
+
+uint8_t* get_report(const ATTESTATION_SESSION_HANDLE& session_handle)
+{
+    UINT32 outputSize = 0;
+
+    enclave_attestation_get_report_params params;
+    params.attestation_session_handle = session_handle;
+    params.report = nullptr;
+    params.buffer_size = 0;
+    params.report_size = 0;
+    params.size = sizeof(enclave_attestation_get_report_params);
+
+    uint8_t* report = nullptr;
+    size_t report_size = 0;
+    att_result hr = att_get_report(session_handle, &report, &report_size);
+    string file_name = "enclave-att-report.jwt";
+    if (!file_name.empty())
+    {
+        ofstream out(file_name, ios::binary);
+        out.write(reinterpret_cast<char*>(report), report_size);
+        cout << "Report saved to " << file_name << "." << endl;
+    }
+    return report;
+}
+
+int __cdecl wmain(int, wchar_t* [])
+{
+    auto tpm_aik = load_tpm_key(AIK_NAME, true);
+    auto tpm_key = create_tpm_key(L"att_sample_key", false);
+
+    att_tpm_aik aik = ATT_TPM_AIK_NCRYPT(tpm_aik.get());
+    create_enclave();
+    initialize();
+
+    vector<BYTE> rp_custom_data{ 0x01, 0x02, 0x03, 0x04 };
+    // TODO: Use relying party's id in the line below.
+    string rp_id{ "https://contoso.com" };
+
+    ATTESTATION_SESSION_HANDLE session_handle{};
+    att_session session{};
+
+    try
+    {
+
+        att_tpm_key key = ATT_TPM_KEY_VBS_NCRYPT(tpm_key.get());
+        // TODO: Use relying party's per-session nonce below.
+        vector<uint8_t> rp_nonce{ 'R', 'E','P','L','A','C','E',' ','W','I','T','H', ' ','R','P', ' ','N','O','N','C','E' };
+
+
+        att_session_params_tpm params
+        {
+            rp_nonce.data(), // relying_party_nonce
+            rp_nonce.size(), // relying_party_nonce_size
+            rp_id.c_str(),   // relying_party_unique_id
+            &aik,            // aik
+            0,               // request_key
+            nullptr,         // other_keys
+            0                // other_keys_count
+        };
+
+#ifdef ATTESTV1
+        log_and_exit_if_failed(att_create_session(rp_custom_data.data(), (UINT32)rp_custom_data.size(), rp_id.c_str(), (UINT32)rp_id.size() + 1, 0, &session_handle),
+            L"CreateSession failed.");
+#else
+        att_result hr = att_create_session(ATT_SESSION_TYPE_VBS, &params, &session);
+        log_and_exit_if_failed(hr, L"CreateSession failed.");
+
+#endif
+    }
+    catch (const std::exception& ex)
+    {
+        cout << ex.what() << endl;
+    }
+
+    bool complete = false;
+    vector<uint8_t> received_from_server{};
+
+    while (!complete)
+    {
+        att_buffer send_to_server = nullptr;
+        size_t send_to_server_size = 0;
+        att_result hr = att_attest(session.get(), received_from_server.data(), received_from_server.size(), &send_to_server, &send_to_server_size, &complete);
+        log_and_exit_if_failed(hr, L"att_attest");
+        if (send_to_server_size > 0)
+        {
+            received_from_server = send_to_att_service(send_to_server.get(), send_to_server_size);
+        }
+    }
+
+    wcout << L"Attestation is complete." << endl;
+
+    uint8_t* report = get_report(session.get());
+    wcout << L"report with size " << sizeof(report) << L" can now be sent to the replying party for parsing" << endl;
+
+    return 0;
+}

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(enclave LANGUAGES C)
+
+set(CMAKE_GENERATOR_TOOLSET v143)
+
+set(CMAKE_GENERATOR_PLATFORM x64)
+
+set(SOURCE_FILES
+    "enclave.c"
+    "sample_enclave.cpp"
+)
+set(PRECOMPILED_HEADER precomp.h)
+
+add_library(vbsenclave SHARED ${SOURCE_FILES})
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL")
+else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+
+target_include_directories(vbsenclave PRIVATE
+    "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.41.34120/include"
+    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/ucrt"
+    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/um"
+    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/shared"
+    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/winrt"
+    "C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/cppwinrt"
+    "D:/VBSEnclave/AzureAttest/inc"
+)
+
+target_link_libraries(vbsenclave PRIVATE
+    "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.41.34120/lib/x64/enclave/libcmt.lib"
+    "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.41.34120/lib/x64/enclave/libvcruntime.lib"
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64/bcrypt.lib"
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/um/x64/vertdll.lib"
+    "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.26100.0/ucrt_enclave/x64/ucrt.lib"
+    "D:/VBSEnclave/AzureAttest/lib/AzureAttest.lib"
+)
+
+target_link_options(vbsenclave PRIVATE /NODEFAULTLIB)
+
+target_precompile_headers(vbsenclave PRIVATE ${PRECOMPILED_HEADER})
+
+target_compile_options(vbsenclave PRIVATE
+    /JMC /permissive- /Zi /Od /sdl
+    /D_DEBUG /D_CONSOLE /D_WINDLL /D_UNICODE /DUNICODE
+    /W3 /WX- /diagnostics:column /Gm- /EHsc /MDd /GS /fp:precise
+    /Zc:wchar_t /Zc:forScope /Zc:inline
+)
+
+target_link_options(vbsenclave PRIVATE
+    /ERRORREPORT:PROMPT
+    #/INCREMENTAL:NO
+    /NOLOGO
+    /NODEFAULTLIB
+    /DEF:${CMAKE_CURRENT_SOURCE_DIR}/vbsenclave.def
+    /MANIFEST
+    /MANIFESTUAC:"level='asInvoker' uiAccess='false'"
+    /MANIFEST:embed
+    /DEBUG
+    /PDB:${CMAKE_BINARY_DIR}/vc143.pdb
+    /SUBSYSTEM:CONSOLE
+    /TLBID:1
+    /DYNAMICBASE
+    /NXCOMPAT
+    /IMPLIB:${CMAKE_BINARY_DIR}/vbsenclave.lib
+    /MACHINE:X64
+    /INTEGRITYCHECK
+    /ENCLAVE
+    /GUARD:MIXED
+    /DLL
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set_target_properties(vbsenclave PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/attestation
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        COMPILE_PDB_NAME vbsenclave
+        COMPILE_PCH vbsenclave.pch
+    )
+
+else()
+    set_target_properties(vbsenclave PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/attestation
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        COMPILE_PCH vbsenclave.pch
+    )
+endif()
+
+set_target_properties(vbsenclave PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/attestation
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    COMPILE_PDB_NAME vbsenclave
+    COMPILE_PCH vbsenclave.pch
+)
+
+add_custom_command(TARGET vbsenclave POST_BUILD
+    COMMAND "C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/veiid.exe" "${CMAKE_BINARY_DIR}/bin/vbsenclave.dll"
+    COMMENT "Applying VEIID Protection"
+)
+
+string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+set (CMAKE_SHARED_LINKER_FLAGS_DEBUG "/DEBUG /INCREMENTAL:NO" CACHE STRING "Overriding default debug ${flag_type} linker flags." FORCE)

--- a/enclave/enclave.c
+++ b/enclave/enclave.c
@@ -1,0 +1,34 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+/*
+    Defines the code that will be loaded into the VBS enclave.
+--*/
+
+#include "precomp.h"
+
+// VBS enclave configuration
+
+const IMAGE_ENCLAVE_CONFIG __enclave_config = {
+    sizeof(IMAGE_ENCLAVE_CONFIG),
+    IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE,
+    IMAGE_ENCLAVE_POLICY_DEBUGGABLE,    // DO NOT SHIP DEBUGGABLE ENCLAVES TO PRODUCTION
+    0,
+    0,
+    0,
+    { 0xFE, 0xFE },    // family id
+    { 0x01, 0x01 },    // image id
+    0,                 // version
+    0,                 // SVN
+    0x10000000,        // size
+    16,                // number of threads
+    IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE
+};

--- a/enclave/precomp.h
+++ b/enclave/precomp.h
@@ -1,0 +1,15 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include <winenclave.h>
+#include <wchar.h>

--- a/enclave/sample_enclave.cpp
+++ b/enclave/sample_enclave.cpp
@@ -1,0 +1,91 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+/*
+    Defines the code that will be loaded into the VBS enclave.
+--*/
+
+#include "precomp.h"
+#include "attest_enclave.h"
+
+ULONG InitialCookie;
+
+BOOL
+DllMain(
+    _In_ HINSTANCE hinstDLL,
+    _In_ DWORD dwReason,
+    _In_ LPVOID lpvReserved
+)
+{
+    UNREFERENCED_PARAMETER(hinstDLL);
+    UNREFERENCED_PARAMETER(lpvReserved);
+
+    if (dwReason == DLL_PROCESS_ATTACH) {
+        InitialCookie = 0xDADAF00D;
+    }
+
+    return TRUE;
+}
+
+extern "C"
+{
+
+    __declspec(dllexport) void* CALLBACK sample_enclave_att_configure(void* param)
+    {
+        WCHAR String[32];
+        swprintf_s(String, ARRAYSIZE(String), L"%s\n", L"att configure started");
+        OutputDebugStringW(String);
+
+        return enclave_att_configure(param, 0);
+    }
+
+    __declspec(dllexport) void* CALLBACK sample_enclave_att_create_session(void* param)
+    {
+        WCHAR String[32];
+        swprintf_s(String, ARRAYSIZE(String), L"%s\n", L"att create session started");
+        OutputDebugStringW(String);
+
+        // any payload you want to put in the report which will get signed.
+        enclave_attestation_property properties[1]{};
+        properties[0]._name = "sample_enclave_property";
+        properties[0]._value_type = enclave_attestation_property_type::enclave_attestation_property_type_string;
+        properties[0]._string = "sample_enclave_string";
+
+        return enclave_att_create_session(param, properties, 1, 0);
+    }
+
+    __declspec(dllexport) void* CALLBACK sample_enclave_att_attest(void* param)
+    {
+        WCHAR String[32];
+        swprintf_s(String, ARRAYSIZE(String), L"%s\n", L"att attest started");
+        OutputDebugStringW(String);
+
+        return enclave_att_attest(param);
+    }
+
+    __declspec(dllexport) void* CALLBACK sample_enclave_att_get_report(void* param)
+    {
+        WCHAR String[32];
+        swprintf_s(String, ARRAYSIZE(String), L"%s\n", L"att get report started");
+        OutputDebugStringW(String);
+
+        return enclave_att_get_report(param);
+    }
+
+    __declspec(dllexport) void* CALLBACK sample_enclave_att_close_session(void* param)
+    {
+        WCHAR String[32];
+        swprintf_s(String, ARRAYSIZE(String), L"%s\n", L"att close session started");
+        OutputDebugStringW(String);
+
+        return enclave_att_close_session(param);
+    }
+}

--- a/enclave/vbsenclave.def
+++ b/enclave/vbsenclave.def
@@ -1,0 +1,8 @@
+LIBRARY
+
+EXPORTS
+        sample_enclave_att_configure
+        sample_enclave_att_create_session
+        sample_enclave_att_attest
+        sample_enclave_att_get_report
+        sample_enclave_att_close_session


### PR DESCRIPTION
**Summary of changes**:
I added a new sample that demonstrates how to use vbs enclave attestation. 

**In this PR**:
- [x] Added a new enclave/ directory that includes the necessary framework to create an enclave dll. This directory compiles into vbsenclave.dll.
- [x] In enclave/ sample_enclave.cpp outlines and returns five exposed enclave attestation functions (enclave_att_configure, enclave_att_create_session, enclave_att_attest, enclave_att_get_report, & enclave_att_close_session).
- [x] Created sample_vbs_att.cpp which demonstrates the vbs enclave attestation process.
- [x] Added send_to_server to attest.h so that I could use it in sample_vbs_att.cpp.
- [x] Appended to attestation/CMakeLists.txt to build the attestation-sample_vbs_att.exe such that it is compatible with the enclave. 

**Callouts for Review**:
- Should I add an attest() function instead of including the functionality directly in main?
- Is there a better way to remove the /RTC1 flag that CMake adds behind the scenes (RTC1 is incompatible with enclaves)?

**To-Do**:
- [ ] Add more comments explaining how new functionality works (ex: initialize_attestation_library function mapping)
- [ ] Merge PR contributing to AzureAttest.dll and azure_attest_manager.dll 